### PR TITLE
improvements to code-generation

### DIFF
--- a/podman-codegen/podman-codegen.cabal
+++ b/podman-codegen/podman-codegen.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.12
 name:                podman-codegen
 synopsis:            A tool to generate haskell types from swagger file
-version:             0.0.0.0
+version:             0.0.0.1
 license:             Apache-2.0
 category:            System
 build-type:          Simple
@@ -28,9 +28,12 @@ executable podman-codegen
 
   build-depends:       base                      < 5
                      , aeson                     >= 1.0.0.0  && < 1.6
+                     , bytestring
                      , insert-ordered-containers
+                     , microlens
                      , mtl
                      , swagger2                  >= 2.4
                      , text                      >= 0.11.1.0 && < 1.3
+                     , wreq
                      , yaml
   main-is:             Codegen.hs


### PR DESCRIPTION

- wreq is used to fetch the swagger file from its location on storage.googleapis.com
- microlens is used to generate lenses
- the generated code now says (both near the top of the file, and in the Haddock docco) that it's auto generated, and from what
- A bunch more data types are now generated. (Will they work? idk.)